### PR TITLE
Differencing Functionality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: climwin
+Package: climwinBH
 Type: Package
 Title: Climate Window Analysis
 Version: 1.1.0

--- a/R/otherfunctions.R
+++ b/R/otherfunctions.R
@@ -237,9 +237,6 @@ basewin <- function(exclude, xvar, cdate, bdate, baseline, range,
   
   cmatrix <- as.matrix(cmatrix[, c(ncol(cmatrix):1)])
   
-  # BH insert: delete the final row for cw_diff = TRUE --> NOT!!
-  # cmatrix = cmatrix[-nrow(cmatrix),]
-  
   if(cmissing == FALSE && length(which(is.na(cmatrix))) > 0){
     if(is.null(spatial) == FALSE){
       

--- a/R/otherfunctions.R
+++ b/R/otherfunctions.R
@@ -158,11 +158,11 @@ basewin <- function(exclude, xvar, cdate, bdate, baseline, range,
     func <- "centre"
   }
   
-  # BH - probably needs updating here for cw_diff: 
-  tmp = diff(modeldat$yvar)
-  modeldat = data.frame(yvar = tmp)
-  # bdate = bdate[2:length(bdate)] --> !!!NOT!!!!
-  # cont$bintno = cont$bintno[2:length(cont$bintno)] --> NOT!!
+  # update in case of differencing 
+  if (cw_diff){
+    tmp = diff(modeldat$yvar)
+    modeldat = data.frame(yvar = tmp)
+  }
   
   ifelse(class(baseline)[length(class(baseline))]=="coxph", leng<-length(modeldat$yvar[,1]), leng<-length(modeldat$yvar))
   if ((leng != length(bdate)) && (!cw_diff)){

--- a/R/randwin.R
+++ b/R/randwin.R
@@ -156,7 +156,8 @@ randwin <- function(exclude = NA, repeats = 5, window = "sliding", xvar, cdate, 
                     upper = NA, lower = NA, binary = FALSE, centre = list(NULL, "both"), k = 0,
                     weightfunc = "W", par = c(3, 0.2, 0), control = list(ndeps = c(0.01, 0.01, 0.01)), 
                     method = "L-BFGS-B", cutoff.day = NULL, cutoff.month = NULL,
-                    furthest = NULL, closest = NULL, thresh = NULL, cvk = NULL){
+                    furthest = NULL, closest = NULL, thresh = NULL, cvk = NULL, 
+                    cw_diff = FALSE){
   
   fast = FALSE
   
@@ -254,7 +255,7 @@ randwin <- function(exclude = NA, repeats = 5, window = "sliding", xvar, cdate, 
                              upper = ifelse(binarylevel == "two" || binarylevel == "upper", allcombos$upper[combo], NA),
                              lower = ifelse(binarylevel == "two" || binarylevel == "lower", allcombos$lower[combo], NA),
                              binary = paste(allcombos$binary[combo]), centre = centre, k = k, spatial = spatial,
-                             cohort = cohort, fast = fast)
+                             cohort = cohort, fast = fast, cw_diff = cw_diff)
         
         outputrep$Repeat <- r
         WeightDist <- sum(as.numeric(cumsum(outputrep$ModWeight) <= 0.95))/nrow(outputrep)

--- a/R/slidingwin.R
+++ b/R/slidingwin.R
@@ -188,7 +188,8 @@ slidingwin <- function(exclude = NA, xvar, cdate, bdate, baseline,
                        spatial = NULL, cohort = NULL, 
                        cutoff.day = NULL, cutoff.month = NULL, 
                        furthest = NULL, closest = NULL,
-                       thresh = NULL, cvk = NULL){
+                       thresh = NULL, cvk = NULL,
+                       cw_diff = FALSE){
   
   fast = FALSE
   
@@ -272,6 +273,7 @@ slidingwin <- function(exclude = NA, xvar, cdate, bdate, baseline,
   print(allcombos)
   
   combined <- list()
+  
   for (combo in 1:nrow(allcombos)){
     runs <- basewin(exclude = exclude, xvar = xvar[[paste(allcombos[combo, 1])]], cdate = cdate, bdate = bdate, baseline = baseline,
                     range = range, type = paste(allcombos[combo, 2]), refday = refday, stat = paste(allcombos[combo, 3]), func = paste(allcombos[combo, 4]),
@@ -279,7 +281,7 @@ slidingwin <- function(exclude = NA, xvar, cdate, bdate, baseline,
                     upper = ifelse(binarylevel == "two" || binarylevel == "upper", allcombos$upper[combo], NA),
                     lower = ifelse(binarylevel == "two" || binarylevel == "lower", allcombos$lower[combo], NA),
                     binary = paste(allcombos$binary[combo]), centre = centre, cohort = cohort,
-                    spatial = spatial, fast = fast)
+                    spatial = spatial, fast = fast, cw_diff = cw_diff)
     
     combined[[combo]]            <- runs
     allcombos$DeltaAICc[combo]   <- round(runs$Dataset$deltaAICc[1], digits = 2)


### PR DESCRIPTION
Dear Liam and Martijn,

In light of my own research using your package, I have introduced a small added extra functionality. I introduced the parameter cw_diff (I didn't call it 'diff', because I prefer to not use parameter names that are names of functions of R), which enables to apply differencing on the time series (applied on both the response variable and the dependent variable). As you know, when working with time series, spurious correlations can often occur due to trend alone. If trends are present in the response variable, the package will also often return P(c) values that indicate that the found time window correlation is likely not to be a false positive, when it is very likely to be a false positive due to trend alone. Off course, this is something the user can or should have accounted for by detrending his data already or including a Time variable in his/her baseline model. However, introducing the option in the package to perform detrending on the data,  I believe gives the package an additional strength. As such, I have made this pull request, so you can consider to include it in future versions.

To the best of my knowledge, the introduced code doesn't seem to interfere with any of the other functionality. However, although I have gotten somewhat familiar with the package's code, I off course do not master everything of it. As the introduced code is limited however, I think you might be able to judge rather quickly whether or not it might interfere with any of its other functionality.  

best regards,

Birgen Haest