### PR TITLE
Update ModWeight calculation to also work with large differences

### DIFF
--- a/R/otherfunctions.R
+++ b/R/otherfunctions.R
@@ -1166,7 +1166,8 @@ basewin <- function(exclude, xvar, cdate, bdate, baseline, range,
   modlist$Statistics   <- stat
   modlist$Type         <- type
   modlist$K            <- k
-  modlist$ModWeight    <- (exp(-0.5 * modlist$deltaAICc)) / sum(exp(-0.5 * modlist$deltaAICc))
+  tmpDeltaAICcShift    <- modlist$deltaAICc - min(modlist$deltaAICc)
+  modlist$ModWeight    <- (exp(-0.5 * tmpDeltaAICcShift)) / sum(exp(-0.5 * tmpDeltaAICcShift))
   modlist$sample.size  <- sample.size
   
   if (type == "absolute"){


### PR DESCRIPTION
Hi Liam,

Bumped into this bug during one of my projects using climwin: If the deltaAIC is very large (i.e. large negative value), the ModWeights end up as NaN, because the exp(-0.5 * deltaAICc) value returns Inf.
You can simply check this by putting in a large value for deltaAICc, for example -300000.

I checked the MuMIn weights calculation:
https://github.com/cran/MuMIn/blob/5849e6f1ae4934ed9729743f1c86bc555d69041c/R/Weights.R

And their solution is to offset the value by the minimum, which indeed seems to fix the bug.