### PR TITLE
Allow for different nr. of dropped columns in case of rank deficiency 

### DIFF
--- a/R/otherfunctions.R
+++ b/R/otherfunctions.R
@@ -1176,7 +1176,7 @@ basewin <- function(exclude, xvar, cdate, bdate, baseline, range,
   
   if(exists("coef_data")){
     
-    modlist <- cbind(modlist, do.call(rbind, coef_data))
+    modlist <- cbind(modlist, dplyr::bind_rows(coef_data))
     
   }
   

--- a/R/randwin.R
+++ b/R/randwin.R
@@ -321,7 +321,7 @@ randwin <- function(exclude = NA, repeats = 5, window = "sliding", xvar, cdate, 
         if(r == 1){ 
           outputrand <- outputrep
         } else { 
-          outputrand <- rbind(outputrand, outputrep)
+          outputrand <- dplyr::bind_rows(outputrand, outputrep)
         }
         
       } else if(window == "weighted"){


### PR DESCRIPTION
Dear Liam et al.,

In my current project, I am running the sliding window analysis with an interaction term for the first time.
The problem is that in some cases lme4 drops different number of columns / coefficients. (**fixed-effect model matrix is rank deficient so dropping .... column / coefficient**). I realise that in these cases I need to have a critical look at the baseline model that I'm using, but it pops up when I'm using snow-data in a location where several months are snow-free, so there's not a really good way around this.

Anyway, because these different number of columns get dropped, `slidingwindow()` and `randomwindow()` will throw an error. I found that if I switch from rbind to dplyr::bind_rows() it will work, and add NA's to the dropped columns. I guess this might mean an extra dependency, but I still wanted to drop this here in case you think this is worth it!

Best, Sanne

p.s. Hope I'm doing this right, as this'll be my first pull request (yay!)

p.p.s. I have used this package for several projects, and it has been a great tool that I recommend to everyone I meet! Thank you for all the time you have invested in this.